### PR TITLE
Fix 3.10 problem of staticmethod being callable

### DIFF
--- a/src/exlog/exceptlog.py
+++ b/src/exlog/exceptlog.py
@@ -87,11 +87,11 @@ def exception_logger_cls(filepath: str, timezone: str = "Etc/UTC") -> Callable[[
 
     def decorator(cls):
         for key, value in vars(cls).items():
-            if callable(value):
-                setattr(cls, key, log(value))
-                continue
             if isinstance(value, (classmethod, staticmethod)):
                 setattr(cls, key, type(value)(log(value.__func__)))
+                continue
+            elif callable(value):
+                setattr(cls, key, log(value))
                 continue
         return cls
 


### PR DESCRIPTION
Fix problem caused by Python 3.10:
> Static methods ([@staticmethod](https://docs.python.org/3/library/functions.html#staticmethod)) and class methods ([@classmethod](https://docs.python.org/3/library/functions.html#classmethod)) now inherit the method attributes (__module__, __name__, __qualname__, __doc__, __annotations__) and have a new __wrapped__ attribute. Moreover, static methods are now callable as regular functions. (Contributed by Victor Stinner in [bpo-43682](https://bugs.python.org/issue43682).)
https://docs.python.org/3/whatsnew/3.10.html
https://bugs.python.org/issue43682